### PR TITLE
docs(controls): with colors examples in sidebar

### DIFF
--- a/docusaurus/docs-internals/editor-controls/data-controls/background-color.md
+++ b/docusaurus/docs-internals/editor-controls/data-controls/background-color.md
@@ -389,3 +389,24 @@ const Page = () => {
   return <BrizyEditor pageData={pageData} projectData={projectData} thirdPartyComponents={thirdPartyComponents} />
 };
 ```
+
+#### Usage in sidebar example
+
+The `backgroundColor` can also be integrated into the sidebar. For improved user experience, it should remain minimized by default and only be rendered as a tooltip on click when invoked within a popover.
+
+```js
+{
+  id: "backgroundColors",
+  type: "popover",
+  label: "Background",
+  config: {
+    title: "Background",
+    icon: {
+      style: {
+        backgroundColor: "green"
+      }
+    }
+  },
+  options: [{ id: "buttonBgColor", type: "backgroundColor" }]
+}
+```

--- a/docusaurus/docs-internals/editor-controls/data-controls/box-shadow.md
+++ b/docusaurus/docs-internals/editor-controls/data-controls/box-shadow.md
@@ -399,3 +399,24 @@ const Page = () => {
   return <BrizyEditor pageData={pageData} projectData={projectData} thirdPartyComponents={thirdPartyComponents} />
 };
 ```
+
+#### Usage in sidebar example
+
+The `boxShadow` can also be integrated into the sidebar. For improved user experience, it should remain minimized by default and only be rendered as a tooltip on click when invoked within a popover.
+
+```js
+{
+  id: "boxShadowColors",
+  type: "popover",
+  label: "Box Shadow",
+  config: {
+    title: "Box Shadow",
+    icon: {
+      style: {
+        backgroundColor: "yellow"
+      }
+    }
+  },
+  options: [{ id: "buttonBoxShadowColor", type: "boxShadow" }]
+}
+```

--- a/docusaurus/docs-internals/editor-controls/data-controls/colorPicker.md
+++ b/docusaurus/docs-internals/editor-controls/data-controls/colorPicker.md
@@ -323,3 +323,25 @@ const Page = () => {
   return <BrizyEditor pageData={pageData} projectData={projectData} thirdPartyComponents={thirdPartyComponents} />
 };
 ```
+
+
+#### Usage in sidebar example
+
+The `colorPicker` can also be integrated into the sidebar. For improved user experience, it should remain minimized by default and only be rendered as a tooltip on click when invoked within a popover.
+
+```js
+{
+  id: "colors",
+  type: "popover",
+  label: "Color",
+  config: {
+    title: "Color",
+    icon: {
+      style: {
+        backgroundColor: "red"
+      }
+    }
+  },
+  options: [{ id: "colorButton", type: "colorPicker" }]
+}
+```

--- a/docusaurus/docs-internals/editor-controls/data-controls/text-shadow.md
+++ b/docusaurus/docs-internals/editor-controls/data-controls/text-shadow.md
@@ -347,3 +347,24 @@ const Page = () => {
   return <BrizyEditor pageData={pageData} projectData={projectData} thirdPartyComponents={thirdPartyComponents} />
 };
 ```
+
+#### Usage in sidebar example
+
+The `textShadow` can also be integrated into the sidebar. For improved user experience, it should remain minimized by default and only be rendered as a tooltip on click when invoked within a popover.
+
+```js
+{
+  id: "textShadowColors",
+  type: "popover",
+  label: "Text Shadow",
+  config: {
+    title: "Text Shadow",
+    icon: {
+      style: {
+        backgroundColor: "blue"
+      }
+    }
+  },
+  options: [{ id: "buttonTextShadowColor", type: "textShadow" }]
+}
+```


### PR DESCRIPTION
Added examples how to use colorPicker, backgroundColor, textShadow and boxShadow with popover in sidebar

Issue: https://github.com/bagrinsergiu/blox-editor/issues/29901